### PR TITLE
Fix root directory permissions

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -335,10 +335,12 @@ func (mfs *MinFS) NextSequence(tx *meta.Tx) (sequence uint64, err error) {
 func (mfs *MinFS) Root() (fs.Node, error) {
 	return &Dir{
 		dir: nil,
-
 		mfs:  mfs,
-		Mode: os.ModeDir | 0555,
 		Path: "",
+
+                UID: mfs.config.uid,
+                GID: mfs.config.gid,
+		Mode: os.ModeDir | 0750,
 	}, nil
 }
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -334,12 +334,12 @@ func (mfs *MinFS) NextSequence(tx *meta.Tx) (sequence uint64, err error) {
 // Root is the root folder of the MinFS mountpoint
 func (mfs *MinFS) Root() (fs.Node, error) {
 	return &Dir{
-		dir: nil,
+		dir:  nil,
 		mfs:  mfs,
 		Path: "",
 
-                UID: mfs.config.uid,
-                GID: mfs.config.gid,
+		UID:  mfs.config.uid,
+		GID:  mfs.config.gid,
 		Mode: os.ModeDir | 0750,
 	}, nil
 }


### PR DESCRIPTION
This fix allow non-root users to write to the mount when using non-root uid,gid mount options.


