### PR TITLE
Add multiarch docker options

### DIFF
--- a/docker-plugin/Dockerfile
+++ b/docker-plugin/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.7-wheezy
+ARG ARCH
+FROM ${ARCH}/golang:1.7-wheezy
 
 WORKDIR /go/src/github.com/minio
 

--- a/docker-plugin/Dockerfile.release
+++ b/docker-plugin/Dockerfile.release
@@ -1,4 +1,5 @@
-FROM golang:1.7-wheezy
+ARG ARCH
+FROM ${ARCH}/golang:1.7-wheezy
 
 WORKDIR /go/src/github.com/minio
 

--- a/docker-plugin/Dockerfile.rootfs
+++ b/docker-plugin/Dockerfile.rootfs
@@ -1,4 +1,5 @@
-FROM golang:1.7-wheezy
+ARG ARCH
+FROM ${ARCH}/golang:1.7-wheezy
 
 COPY . /go/src/github.com/minio/minfs-docker-plugin
 WORKDIR /go/src/github.com/minio/minfs-docker-plugin

--- a/docker-plugin/Makefile
+++ b/docker-plugin/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=minio/minfs
 PLUGIN_TAG=latest
+PLUGIN_ARCH=amd64 # known namespaces: https://github.com/docker-library/official-images#architectures-other-than-amd64
 
 # Default is to build development plugin.
 all: clean docker rootfs create enable
@@ -13,7 +14,7 @@ clean:
 
 docker:
 	@echo "### docker build: builder image"
-	@docker build -q -t builder -f Dockerfile.rootfs .
+	@docker build --build-arg ARCH=${PLUGIN_ARCH} -q -t builder -f Dockerfile.rootfs .
 	@echo "### extract minfs-docker-plugin"
 	@docker create --name tmp builder
 	@docker cp tmp:/go/bin/minfs-docker-plugin .
@@ -32,18 +33,18 @@ docker:
 	@cp -a ../vendor minfs
 	@cp -a ../.git minfs
 	@echo "### docker build: rootfs image with minfs-docker-plugin"
-	@docker build -t ${PLUGIN_NAME}:rootfs .
+	@docker build --build-arg ARCH=${PLUGIN_ARCH} -t ${PLUGIN_NAME}:rootfs .
 
 docker-release:
 	@echo "### docker build: builder image"
-	@docker build -q -t builder -f Dockerfile.rootfs .
+	@docker build --build-arg ARCH=${PLUGIN_ARCH} -q -t builder -f Dockerfile.rootfs .
 	@echo "### extract minfs-docker-plugin"
 	@docker create --name tmp builder
 	@docker cp tmp:/go/bin/minfs-docker-plugin .
 	@docker rm -vf tmp
 	@docker rmi builder
 	@echo "### docker build: rootfs image with minfs-docker-plugin"
-	@docker build -f Dockerfile.release -q -t ${PLUGIN_NAME}:rootfs .
+	@docker build --build-arg ARCH=${PLUGIN_ARCH} -f Dockerfile.release -q -t ${PLUGIN_NAME}:rootfs .
 
 rootfs:
 	@echo "### create rootfs directory in ./plugin/rootfs"


### PR DESCRIPTION
This adds the option to specify the architecture which to use in the Docker build. This allows for the plugin to be used on multiple platforms.
For release this should use a Manifest (https://github.com/estesp/manifest-tool, hopefully soon inside Docker itself) but I was unable to find where this is being built.

Feedback welcome!